### PR TITLE
Fix asset paths to avoid 404 errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,6 @@ import sectionsConfig from './config/sectionsConfig';
 import Scene from './components/Scene';
 import { scrollToSection } from './utils/scroll';
 
-const BASE = import.meta.env.BASE_URL;
 
 // 各セクションの設定（dummy テキストは改行 "\n" で可変）
 const sections = [
@@ -92,7 +91,7 @@ export default function App() {
 
       {/* TOPに戻るボタン */}
         <img
-          src={`${BASE}img/return.png`}
+          src="img/return.png"
           alt="return"
           className="return-button"
           onClick={() => setIdx(0)}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,6 @@ import { FaBars, FaTimes  } from 'react-icons/fa';  // FaTimes はオーバー�
 import { motion, AnimatePresence } from 'framer-motion';
 import { scrollToSection } from '../utils/scroll';
 
-const BASE = import.meta.env.BASE_URL;
 
 const links = [
 //   { id: 'first',   label: 'ファーストビュー' },
@@ -49,7 +48,7 @@ export default function Header({ onSelect, isFirst, setMenuOpen }) {
       >
         {/* 左：ロゴ */}
           <img
-            src={`${BASE}img/logo.png`}
+            src="img/logo.png"
             alt="logo"
             className={`logo ${isFirst ? 'logo-large' : ''}`}
             onClick={() => handleNavClick('first')}

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -6,7 +6,7 @@ import { EXRLoader } from 'three-stdlib';                            // EXRLoade
 import { PMREMGenerator, LinearToneMapping, sRGBEncoding } from 'three';
 import { useGLTF } from '@react-three/drei';
 
-const MODEL_PATH = `${import.meta.env.BASE_URL}model.glb`;       // public/model.glb が存在すること
+const MODEL_PATH = 'model.glb';       // public/model.glb が存在すること
 
 export default function Scene({ activeCamera }) {
   const { camera, scene, gl, size } = useThree();

--- a/src/components/sections/LinkSection.jsx
+++ b/src/components/sections/LinkSection.jsx
@@ -2,34 +2,33 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 
-const BASE = import.meta.env.BASE_URL;
 
 export default function LinkSection() {
   // ★ アイコン・URL・QRパス・ボタンテキストを配列で管理
   const links = [
     {
-      icon: `${BASE}img/icons/x_icon.png`,
+      icon: 'img/icons/x_icon.png',
       url: 'https://github.com/your-username',
-      qr: `${BASE}img/icons/x_qr.png`,
+      qr: 'img/icons/x_qr.png',
       alt: 'X',
       buttonText: 'X',
-      buttonIcon: `${BASE}img/icons/link_icon.png`,
+      buttonIcon: 'img/icons/link_icon.png',
     },
     {
-      icon: `${BASE}img/icons/instagram_icon.png`,
+      icon: 'img/icons/instagram_icon.png',
       url: 'https://twitter.com/your-username',
-      qr: `${BASE}img/icons/instagram_qr.png`,
+      qr: 'img/icons/instagram_qr.png',
       alt: 'Instagram',
       buttonText: 'Instagram',
-      buttonIcon: `${BASE}img/icons/link_icon.png`,
+      buttonIcon: 'img/icons/link_icon.png',
     },
     {
-      icon: `${BASE}img/icons/line_stamp.png`,
+      icon: 'img/icons/line_stamp.png',
       url: 'https://www.linkedin.com/in/your-username',
-      qr: `${BASE}img/icons/stamp_qr.png`,
+      qr: 'img/icons/stamp_qr.png',
       alt: 'LINEスタンプ',
       buttonText: 'LINEスタンプ',
-      buttonIcon: `${BASE}img/icons/link_icon.png`,
+      buttonIcon: 'img/icons/link_icon.png',
     },
   ];
 


### PR DESCRIPTION
## Summary
- use relative paths for static assets so they work on GitHub Pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e75c2400083289ac0b49a8de5546b