### PR TITLE
Enable first-view 3D rotation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ const sections = [
 export default function App() {
   const [idx, setIdx] = useState(0);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [modelRotY, setModelRotY] = useState(0);
+  const dragging = useRef({ active: false, startX: 0, startRot: 0 });
   const scrolling = useRef(false);
 
   // マウスホイールで idx を変更
@@ -34,9 +36,26 @@ export default function App() {
     }
   }, [idx]);
 
+  // ドラッグ操作でモデルを回転
+  const onPointerDown = useCallback(e => {
+    if (idx !== 0) return;
+    dragging.current = { active: true, startX: e.clientX, startRot: modelRotY };
+  }, [idx, modelRotY]);
+
+  const onPointerMove = useCallback(e => {
+    if (!dragging.current.active) return;
+    const delta = e.clientX - dragging.current.startX;
+    setModelRotY(dragging.current.startRot + delta * 0.005);
+  }, []);
+
+  const endDrag = useCallback(() => {
+    dragging.current.active = false;
+  }, []);
+
   // idx が変わったらスクロール＆カメラを移動
   useEffect(() => {
     scrollToSection(sections[idx].id);
+    if (idx !== 0) setModelRotY(0);
     const t = setTimeout(() => scrolling.current = false, 1000);
     return () => clearTimeout(t);
   }, [idx]);
@@ -51,7 +70,13 @@ export default function App() {
       />
 
       {/* 3D Canvas */}
-      <div className="canvas-container">
+      <div
+        className="canvas-container"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerLeave={endDrag}
+      >
         <Canvas
           // ← here we explicitly set the same lens you had before:
           camera={{ fov: 38.6, near: 0.1, far: 1000 }}
@@ -59,7 +84,10 @@ export default function App() {
           <ambientLight intensity={0.3} />
           <directionalLight intensity={0.5} position={[25, 40,50]} />
           <Suspense fallback={null}>
-            <Scene activeCamera={sectionsConfig[idx].camera} />
+            <Scene
+              activeCamera={sectionsConfig[idx].camera}
+              modelRotY={modelRotY}
+            />
           </Suspense>
         </Canvas>
       </div>

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -8,9 +8,10 @@ import { useGLTF } from '@react-three/drei';
 
 const MODEL_PATH = 'model.glb';       // public/model.glb が存在すること
 
-export default function Scene({ activeCamera }) {
+export default function Scene({ activeCamera, modelRotY = 0 }) {
   const { camera, scene, gl, size } = useThree();
   const mixer = useRef();
+  const modelRef = useRef();
   const camerasMap = useRef({});
 
   // (2) カメラターゲット用
@@ -34,6 +35,7 @@ export default function Scene({ activeCamera }) {
 
     // -- モデルをシーンに追加 --
     scene.add(gltf.scene);
+    modelRef.current = gltf.scene;
 
     // -- アニメーション準備 --
     mixer.current = new THREE.AnimationMixer(gltf.scene);
@@ -94,6 +96,10 @@ export default function Scene({ activeCamera }) {
   // 毎フレーム：アニメーション更新・カメラ補間・レンダー
   useFrame((_, delta) => {
     mixer.current?.update(delta);
+
+    if (modelRef.current) {
+      modelRef.current.rotation.y = modelRotY;
+    }
 
     camera.aspect = size.width / size.height;
     camera.updateProjectionMatrix();


### PR DESCRIPTION
## Summary
- make the 3D model rotatable with drag on the first section
- reset rotation when leaving the first section

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_684e898483d883289d7df565737ec4fa